### PR TITLE
setting up a OIDC to AWS account for pipeline terraform access

### DIFF
--- a/.github/workflows/tf-apply.yaml
+++ b/.github/workflows/tf-apply.yaml
@@ -13,7 +13,7 @@ jobs:
     env:
       AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
       AWS_REGION: ${{ vars.AWS_REGION }}
-      ROLE_NAME: ${{ vars.TERRAFORM_ROLE_NAME }}
+      TERRAFORM_ROLE_NAME: ${{ vars.TERRAFORM_ROLE_NAME }}
     steps:
     - uses: actions/checkout@v4
     - name: Setup Terraform

--- a/.github/workflows/tf-apply.yaml
+++ b/.github/workflows/tf-apply.yaml
@@ -7,19 +7,26 @@ on:
 jobs:
   terraform-apply:
     runs-on: ubuntu-24.04
+    env:
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      ROLE_NAME: ${{ vars.TERRAFORM_ROLE_NAME }}
     steps:
     - uses: actions/checkout@v4
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: 1.9.1
+    
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ env.TERRAFORM_ROLE_NAME }}
+        aws-region: ${{ env.AWS_REGION }}
 
     - name: Terraform Init
       working-directory: ./infrastructure/terraform/
       run: terraform init
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     
     - name: Terraform Apply
       working-directory: ./infrastructure/terraform/

--- a/.github/workflows/tf-apply.yaml
+++ b/.github/workflows/tf-apply.yaml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
 
 jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
   terraform-apply:
     runs-on: ubuntu-24.04
     env:

--- a/.github/workflows/tf-apply.yaml
+++ b/.github/workflows/tf-apply.yaml
@@ -5,12 +5,11 @@ on:
     branches: [ main ]
 
 jobs:
-  deploy:
+  terraform-apply:
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
       contents: read
-  terraform-apply:
-    runs-on: ubuntu-24.04
     env:
       AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
       AWS_REGION: ${{ vars.AWS_REGION }}

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -19,7 +19,7 @@ jobs:
     env:
       AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
       AWS_REGION: ${{ vars.AWS_REGION }}
-      ROLE_NAME: ${{ vars.TERRAFORM_ROLE_NAME }}
+      TERRAFORM_ROLE_NAME: ${{ vars.TERRAFORM_ROLE_NAME }}
     steps:
     - uses: actions/checkout@v4
     - name: Setup Terraform

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -11,6 +11,10 @@ on:
       - '.github/workflows/terraform.yml'
 
 jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
   terraform-plan:
     runs-on: ubuntu-24.04
     env:

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -13,12 +13,22 @@ on:
 jobs:
   terraform-plan:
     runs-on: ubuntu-24.04
+    env:
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      ROLE_NAME: ${{ vars.TERRAFORM_ROLE_NAME }}
     steps:
     - uses: actions/checkout@v4
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: 1.9.1
+    
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ env.TERRAFORM_ROLE_NAME }}
+        aws-region: ${{ env.AWS_REGION }}
 
     - name: Terraform Format Check
       working-directory: ./infrastructure/terraform/
@@ -31,16 +41,10 @@ jobs:
     - name: Terraform Init
       working-directory: ./infrastructure/terraform/
       run: terraform init
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     
     - name: Terraform Plan
       id: plan
       working-directory: ./infrastructure/terraform/
       run: terraform plan -no-color
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -11,12 +11,11 @@ on:
       - '.github/workflows/terraform.yml'
 
 jobs:
-  deploy:
+  terraform-plan:
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
       contents: read
-  terraform-plan:
-    runs-on: ubuntu-24.04
     env:
       AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
       AWS_REGION: ${{ vars.AWS_REGION }}

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ terraform-plan:
     env:
       AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
       AWS_REGION: ${{ vars.AWS_REGION }}
-      ROLE_NAME: ${{ vars.TERRAFORM_ROLE_NAME }}
+      TERRAFORM_ROLE_NAME: ${{ vars.TERRAFORM_ROLE_NAME }}
 ```
 - You will need to add all values under the `env` section as environmental variables
 in the GitHub Actions settings section of the repo or globally for the whole Org.

--- a/README.md
+++ b/README.md
@@ -83,9 +83,17 @@ terraform-plan:
 ```
 - You will need to add all values under the `env` section as environmental variables
 in the GitHub Actions settings section of the repo or globally for the whole Org.
-8. Use the credentials in your Terraform steps:
+8. Add this to your GitHub Actions Workflow as well:
+```
+jobs:
+  deploy:
+    permissions:
+      id-token: write
+      contents: read
+```
+9. Use the credentials in your Terraform steps:
     - The AWS credentials will be automatically available to Terraform.
-9. Ensure your Terraform code uses the assumed role:
+10. Ensure your Terraform code uses the assumed role:
     - In your Terraform AWS provider configuration, you don't need to specify credentials. Terraform will use the credentials from the environment.
 
 By following these steps, you'll set up a secure OIDC connection between GitHub Actions and AWS. This method eliminates the need for long-lived AWS access keys, enhancing security. The IAM role's trust policy ensures that only your specified GitHub repository can assume the role, providing an additional layer of security

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ in the GitHub Actions settings section of the repo or globally for the whole Org
 8. Add this to your GitHub Actions Workflow as well:
 ```
 jobs:
-  deploy:
+  terraform-apply:
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
       contents: read

--- a/README.md
+++ b/README.md
@@ -1,1 +1,91 @@
 # scrappr-site
+
+## Setup Outside of Code Deploy:
+
+### Connect to AWS through OIDC for GitHub Actions to Use Terraform
+
+#### Configure AWS as an OIDC provider:
+1. Log in to your AWS Console and go to IAM.
+2. Select "Identity providers" and click "Add provider".
+3. Choose "OpenID Connect" as the provider type.
+For the provider URL, enter: `https://token.actions.githubusercontent.com`
+For the "Audience", enter: `sts.amazonaws.com`
+Click "Get thumbprint" and then "Add provider".
+4. Create an IAM role for GitHub Actions:
+    - In IAM, go to "Roles" and click "Create role".
+    - Select "Web Identity" under "Trusted entity type".
+    - Choose the GitHub identity provider you just created.
+    - For the Audience, select `sts.amazonaws.com`
+    - Create a new role (e.g., "GitHubActionsRole")
+    - Choose "Web Identity" as the trusted entity
+    - Select the OIDC provider you created for GitHub (`token.actions.githubusercontent.com`)
+    - Add the necessary permissions for your Terraform operations.
+    - Set a trust policy to restrict access to your specific GitHub repo:
+    ```
+    {
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::YOUR_AWS_ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+            "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+            "token.actions.githubusercontent.com:sub": "repo:YourGitHubOrg/*"
+        }
+      }
+    }
+  ]
+}
+```
+5. Set the permissions for Terraform (your needs may differ):
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:*",
+        "s3:*",
+        "dynamodb:*",
+        "iam:*",
+        "cloudwatch:*"
+        // Add other necessary permissions
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+6. Attach the policy to the role.
+7. In your GitHub Actions Workflow us this action:
+```
+- name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ env.TERRAFORM_ROLE_NAME }}
+        aws-region: ${{ env.AWS_REGION }}
+```
+and update the code at the top to look like this:
+```
+terraform-plan:
+    runs-on: ubuntu-24.04
+    env:
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      ROLE_NAME: ${{ vars.TERRAFORM_ROLE_NAME }}
+```
+- You will need to add all values under the `env` section as environmental variables
+in the GitHub Actions settings section of the repo or globally for the whole Org.
+8. Use the credentials in your Terraform steps:
+    - The AWS credentials will be automatically available to Terraform.
+9. Ensure your Terraform code uses the assumed role:
+    - In your Terraform AWS provider configuration, you don't need to specify credentials. Terraform will use the credentials from the environment.
+
+By following these steps, you'll set up a secure OIDC connection between GitHub Actions and AWS. This method eliminates the need for long-lived AWS access keys, enhancing security. The IAM role's trust policy ensures that only your specified GitHub repository can assume the role, providing an additional layer of security


### PR DESCRIPTION
I am setting up a more secure way to connect AWS, Terraform, and GitHub with OIDC. OIDC eliminates the need for long-lived AWS access keys, which can be a security risk if compromised. It uses short-lived credentials, reducing the window of opportunity for potential attacker